### PR TITLE
Update sam_bot_description.urdf

### DIFF
--- a/sam_bot_description/src/description/sam_bot_description.urdf
+++ b/sam_bot_description/src/description/sam_bot_description.urdf
@@ -240,7 +240,7 @@
 
       <!-- output -->
       <publish_odom>true</publish_odom>
-      <publish_odom_tf>true</publish_odom_tf>
+      <publish_odom_tf>false</publish_odom_tf>
       <publish_wheel_tf>true</publish_wheel_tf>
 
       <odometry_frame>odom</odometry_frame>


### PR DESCRIPTION
Disable `publish_odom_tf` of Gazebo diff drive plugin. The `odom`=>`base_link` transform is set to be published by `robot_localization`